### PR TITLE
datetime: use int64 instead of float64

### DIFF
--- a/template/helpers.go
+++ b/template/helpers.go
@@ -46,22 +46,22 @@ func init() {
 	raymond.RegisterHelpers(funcs)
 }
 
-func toDuration(started, finished float64) string {
+func toDuration(started, finished int64) string {
 	return fmt.Sprint(time.Duration(finished-started) * time.Second)
 }
 
-func toDatetime(timestamp float64, layout, zone string) string {
+func toDatetime(timestamp int64, layout, zone string) string {
 	if len(zone) == 0 {
-		return time.Unix(int64(timestamp), 0).Format(layout)
+		return time.Unix(timestamp, 0).Format(layout)
 	}
 
 	loc, err := time.LoadLocation(zone)
 
 	if err != nil {
-		return time.Unix(int64(timestamp), 0).Local().Format(layout)
+		return time.Unix(timestamp, 0).Local().Format(layout)
 	}
 
-	return time.Unix(int64(timestamp), 0).In(loc).Format(layout)
+	return time.Unix(timestamp, 0).In(loc).Format(layout)
 }
 
 func isSuccess(conditional bool, options *raymond.Options) string {

--- a/template/helpers_test.go
+++ b/template/helpers_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestToDuration(t *testing.T) {
-	from := float64(time.Date(2017, time.November, 15, 23, 0, 0, 0, time.UTC).Unix())
+	from := time.Date(2017, time.November, 15, 23, 0, 0, 0, time.UTC).Unix()
 
 	vals := map[int64]string{
 		time.Date(2018, time.November, 15, 23, 0, 0, 0, time.UTC).Unix():   "8760h0m0s",
@@ -33,8 +33,8 @@ func TestToDuration(t *testing.T) {
 	}
 
 	for input, want := range vals {
-		if got := toDuration(from, float64(input)); got != want {
-			t.Errorf("Want transform %f-%f to %s, got %s", from, float64(input), want, got)
+		if got := toDuration(from, input); got != want {
+			t.Errorf("Want transform %d-%d to %s, got %s", from, input, want, got)
 		}
 	}
 }


### PR DESCRIPTION
Hello,

I am using the slack plugin (https://github.com/drone-plugins/drone-slack) for Drone and I would like to use the `datetime` function in the template.

At start, I was a little confused by the documentation (http://plugins.drone.io/drone-plugins/drone-slack/) which says: 
```
datetime: converts a unix timestamp to a date time string. Example {{datetime build.started}}
```

And the 0.4 documentation (http://readme.drone.io/0.4/usage/notify/) says:
```
Converts a timestamp to a human readable string:
finished at {{ datetime build.finished_at "3:04PM" "UTC" }}
```

After some testing, I figured out that the right thing to do was using "build.started" (as `build.finished_at` and `build.started_at` are empty) and to give 3 arguments.

So, my step looks like this:
```
slack-test:
    image: plugins/slack
    webhook: https://hooks.slack.com/services/...
    recipient: lucille
    when:
      event: push
    template: >
      This is a test {{ datetime build.started "3:04PM" "UTC" }}
```

In drone, I get the error: 
```
Evaluation error: Helper datetime called with argument 0 with type int64 but it should be float64
```

In drone-slack, `started` is of type int64 and the template ask for a float64.
https://github.com/drone-plugins/drone-slack/blob/master/main.go#L184

I may be missing something, but I don't understand why `toDatetime` is using a float64 as a cast to int64 is done just after... So I think that the right solution may be to fix drone-template-lib to use a int64 instead of using a float64 in drone-slack.

Thank you!