### PR TITLE
Add new tempalte functions for trimming unneeded spaces in strings

### DIFF
--- a/template/helpers.go
+++ b/template/helpers.go
@@ -41,8 +41,8 @@ var (
 		"lowercase":      strings.ToLower,
 		"regexReplace":   regexReplace,
 		"trim":           trimSpace,
-		"trimLeft":       trimLeft,
-		"trimRight":      trimRight,
+		"trimleft":       trimLeft,
+		"trimright":      trimRight,
 	}
 )
 

--- a/template/helpers.go
+++ b/template/helpers.go
@@ -40,6 +40,9 @@ var (
 		"uppercase":      strings.ToUpper,
 		"lowercase":      strings.ToLower,
 		"regexReplace":   regexReplace,
+		"trim":           trimSpace,
+		"trimLeft":       trimLeft,
+		"trimRight":      trimRight,
 	}
 )
 
@@ -130,6 +133,18 @@ func uppercaseFirst(s string) string {
 func regexReplace(pattern string, input string, replacement string) string {
 	re := regexp.MustCompile(pattern)
 	return re.ReplaceAllString(input, replacement)
+}
+
+func trimLeft(s string) string {
+	return strings.TrimLeft(s, "\r\n")
+}
+
+func trimRight(s string) string {
+	return strings.TrimRight(s, "\r\n")
+}
+
+func trimSpace(s string) string {
+	return strings.TrimSpace(s)
 }
 
 func invalidHelper(name string) bool {

--- a/template/helpers_test.go
+++ b/template/helpers_test.go
@@ -98,3 +98,33 @@ func TestRegexReplace(t *testing.T) {
 		t.Errorf("error, expected %s, got %s", expected, actual)
 	}
 }
+
+func TestTrimLeft(t *testing.T) {
+	vals := map[string]string{
+		"hello\n":         "hello\n",
+		"\nhello\n":       "hello\n",
+		"\r\nhello\n":     "hello\n",
+		"\n\r\nhello\r\n": "hello\r\n",
+	}
+
+	for input, want := range vals {
+		if got := trimLeft(input); got != want {
+			t.Errorf("Want to left trim spaces from string %s to %s, got %s", input, want, got)
+		}
+	}
+}
+
+func TestTrimRight(t *testing.T) {
+	vals := map[string]string{
+		"\nhello":         "\nhello",
+		"\nhello\n":       "\nhello",
+		"\nhello\r\n":     "\nhello",
+		"\r\nhello\n\r\n": "\r\nhello",
+	}
+
+	for input, want := range vals {
+		if got := trimRight(input); got != want {
+			t.Errorf("Want to left trim spaces from string %s to %s, got %s", input, want, got)
+		}
+	}
+}


### PR DESCRIPTION
Hi. In some cases, meta fields contain unneeded new line characters. I add three new template functions:
- trim for trimming leading and trailing spaces
- trimLeft
- trimRight
Please, add this functions to main branch for start using it in telegram plugin=)
Thanks and have a good day! 