### PR TITLE
Html line breaks

### DIFF
--- a/template/helpers.go
+++ b/template/helpers.go
@@ -42,6 +42,7 @@ var (
 		"lowercase":        strings.ToLower,
 		"regexReplace":     regexReplace,
 		"safeRegexReplace": safeRegexReplace,
+		"htmlLineBreaks":   htmlLineBreaks,
 	}
 )
 
@@ -141,6 +142,10 @@ func regexReplace(pattern string, input string, replacement string) string {
 
 func safeRegexReplace(pattern string, input string, replacement string) raymond.SafeString {
 	return raymond.SafeString(regexReplace(pattern, input, replacement))
+}
+
+func htmlLineBreaks(input string) raymond.SafeString {
+	return safeRegexReplace("\n", input, "<br>")
 }
 
 func invalidHelper(name string) bool {

--- a/template/helpers.go
+++ b/template/helpers.go
@@ -30,17 +30,18 @@ import (
 
 var (
 	funcs = map[string]interface{}{
-		"duration":       toDuration,
-		"datetime":       toDatetime,
-		"success":        isSuccess,
-		"failure":        isFailure,
-		"truncate":       truncate,
-		"urlencode":      urlencode,
-		"since":          since,
-		"uppercasefirst": uppercaseFirst,
-		"uppercase":      strings.ToUpper,
-		"lowercase":      strings.ToLower,
-		"regexReplace":   regexReplace,
+		"duration":         toDuration,
+		"datetime":         toDatetime,
+		"success":          isSuccess,
+		"failure":          isFailure,
+		"truncate":         truncate,
+		"urlencode":        urlencode,
+		"since":            since,
+		"uppercasefirst":   uppercaseFirst,
+		"uppercase":        strings.ToUpper,
+		"lowercase":        strings.ToLower,
+		"regexReplace":     regexReplace,
+		"safeRegexReplace": safeRegexReplace,
 	}
 )
 
@@ -136,6 +137,10 @@ func uppercaseFirst(s string) string {
 func regexReplace(pattern string, input string, replacement string) string {
 	re := regexp.MustCompile(pattern)
 	return re.ReplaceAllString(input, replacement)
+}
+
+func safeRegexReplace(pattern string, input string, replacement string) raymond.SafeString {
+	return raymond.SafeString(regexReplace(pattern, input, replacement))
 }
 
 func invalidHelper(name string) bool {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,0 +1,32 @@
+// Copyright 2018 Drone.IO Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template
+
+import (
+	"testing"
+)
+
+func TestRender(t *testing.T) {
+	template := `<p>{{ safeRegexReplace "\n" content "<br>" }}</p>`
+	ctx := map[string]string{
+    "content": "hello\nworld",
+	}
+
+	expected  := "<p>hello<br>world</p>"
+	actual, _ := Render(template, ctx)
+	if actual != expected {
+		t.Errorf("error, expected %s, got %s", expected, actual)
+	}
+}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -18,14 +18,26 @@ import (
 	"testing"
 )
 
+const template = `
+<p>{{ safeRegexReplace "\n" hello_world "<br>" }}</p>
+<p>{{ htmlLineBreaks lorem_ipsum }}</p>
+`
+
+const expected = `
+<p>hello<br>world</p>
+<p>lorem ipsum<br>sit dolor<br></p>
+`
+
 func TestRender(t *testing.T) {
-	template := `<p>{{ safeRegexReplace "\n" content "<br>" }}</p>`
 	ctx := map[string]string{
-    "content": "hello\nworld",
+		"hello_world": "hello\nworld",
+		"lorem_ipsum": "lorem ipsum\nsit dolor\n",
 	}
 
-	expected  := "<p>hello<br>world</p>"
-	actual, _ := Render(template, ctx)
+	actual, err := Render(template, ctx)
+	if err != nil {
+		t.Errorf("error, %v", err)
+	}
 	if actual != expected {
 		t.Errorf("error, expected %s, got %s", expected, actual)
 	}


### PR DESCRIPTION
i'm trying to do this in a template:

`{{ regexReplace "\n" commit.message "<br>" }}`

to get better html formatting in emails sent by [drillster/drone-email](https://github.com/Drillster/drone-email).

only it does not work because raymond will escape values returned from helpers unless it's wrapped with `raymend.SafeString`.

here i implement `safeRegexReplace` and the more specific `htmlLineBreaks` helpers to allow things like this and give a specific helper for the use-case.